### PR TITLE
Enable NaturalCrit projects via config file

### DIFF
--- a/client/naturalcrit/homePage/homePage.jsx
+++ b/client/naturalcrit/homePage/homePage.jsx
@@ -26,7 +26,7 @@ const HomePage = React.createClass({
 					{
 						id : 'badges',
 						path : 'http://naturalcrit.com/badges',
-						name : 'Achivement Badges',
+						name : 'Achievement Badges',
 						icon : <BadgeIcon />,
 						desc : 'Create simple badges to award your players',
 
@@ -43,8 +43,22 @@ const HomePage = React.createClass({
 						show : false,
 						beta : true
 					},
+				],
+				configTools : {}
+			};
+		},
 
-				]
+		getInitialState(){
+			const newTools = _.map(this.props.tools, (tool)=>{
+				if(this.props.configTools[tool.id]){
+					const configTool = this.props.configTools[tool.id];
+					if(typeof(configTool.path) != 'undefined'){ tool.path = configTool.path; };
+					if(typeof(configTool.show) != 'undefined'){ tool.show = configTool.show; };
+				}
+				return tool;
+			});
+			return {
+				tools : newTools
 			};
 		},
 
@@ -61,7 +75,7 @@ const HomePage = React.createClass({
 		},
 
 		renderTools : function(){
-			return _.map(this.props.tools, (tool)=>{
+			return _.map(this.state.tools, (tool)=>{
 				return this.renderTool(tool);
 			});
 		},

--- a/client/naturalcrit/naturalcrit.jsx
+++ b/client/naturalcrit/naturalcrit.jsx
@@ -40,10 +40,12 @@ const Naturalcrit = React.createClass({
 					user={this.props.user} />
 			},
 			'*' : () => {
-				return <HomePage />
+				return <HomePage 
+					configTools={this.props.tools} />
 			}
 		});
 	},
+
 	render : function(){
 		return <div className='naturalcrit'>
 			<Router initialUrl={this.props.url}/>

--- a/config/default.json
+++ b/config/default.json
@@ -1,5 +1,16 @@
 {
-	"host" : "local.naturalcrit.com:8010",
-	"domain" : ".local.naturalcrit.com",
-	"secret" : "secret"
+	"host" : "localhost:8010",
+	"domain" : ".localhost:8010",
+	"secret" : "secret",
+	"tools" : {
+		"homebrew" : {
+			"show" : true			
+		},
+		"badges" : {
+			"show" : true
+		},
+		"tpk" : {
+			"show" : false
+		}
+	}
 }

--- a/server.js
+++ b/server.js
@@ -52,7 +52,9 @@ app.use('/auth', authRoutes);
 
 //Homebrew Redirect
 app.all('/homebrew*', (req, res) => {
-	return res.redirect(302, 'http://homebrewery.naturalcrit.com' + req.url.replace('/homebrew', ''));
+	const tools = config.get("tools");
+	const homebrewPath = (typeof(tools["homebrew"].path) != 'undefined' ? tools['homebrew'].path : 'https://homebrewery.naturalcrit.com');
+	return res.redirect(302, homebrewPath + req.url.replace('/homebrew', ''));
 });
 
 
@@ -71,7 +73,8 @@ app.get('*', (req, res) => {
 			url : req.url,
 			user : req.user,
 			//authToken : authToken,
-			domain : config.get('domain')
+			domain : config.get('domain'),
+			tools : config.get('tools')
 		})
 		.then((page) => res.send(page))
 		.catch((err) => console.log(err));


### PR DESCRIPTION
This PR seeks to allow the configuration of the various NaturalCrit projects and the URL to access them via items in the `config` folder.

This is achieved by creating a "tools" object in the `config/default.json` for each of the NaturalCrit projects. The default options for the tools are still set in the `HomePage.jsx` but the `show` and `path` settings are overriden by any settings in the `config/default.json` (or `config/local.json` for local installations).