### PR TITLE
Fix redirect after Google login

### DIFF
--- a/client/naturalcrit/loginPage/loginPage.jsx
+++ b/client/naturalcrit/loginPage/loginPage.jsx
@@ -43,9 +43,9 @@ const LoginPage = React.createClass({
 
 	handleRedirectURL : function() {
 		if(!this.props.redirect) { 
-			return window.localStorage.removeItem(RedirectLocation);
+			return window.sessionStorage.removeItem(RedirectLocation);
 		};
-		return window.localStorage.setItem(RedirectLocation, this.props.redirect);
+		return window.sessionStorage.setItem(RedirectLocation, this.props.redirect);
 	},
 
 	handleUserChange : function(e){

--- a/client/naturalcrit/loginPage/loginPage.jsx
+++ b/client/naturalcrit/loginPage/loginPage.jsx
@@ -5,6 +5,8 @@ const cx    = require('classnames');
 const NaturalCritIcon = require('naturalcrit/svg/naturalcrit.svg.jsx');
 const AccountActions = require('../account.actions.js');
 
+const RedirectLocation = 'NC-REDIRECT-URL';
+
 
 const LoginPage = React.createClass({
 	getDefaultProps: function() {
@@ -35,8 +37,16 @@ const LoginPage = React.createClass({
 		window.document.onkeypress = (e)=>{
 			if(e.code == 'Enter') this.handleClick();
 		}
+
+		this.handleRedirectURL();
 	},
 
+	handleRedirectURL : function() {
+		if(!this.props.redirect) { 
+			return window.localStorage.removeItem(RedirectLocation);
+		};
+		return window.localStorage.setItem(RedirectLocation, this.props.redirect);
+	},
 
 	handleUserChange : function(e){
 		this.setState({

--- a/client/naturalcrit/successPage/successPage.jsx
+++ b/client/naturalcrit/successPage/successPage.jsx
@@ -33,8 +33,8 @@ const SuccessPage = React.createClass({
 		};
 	},
 	componentDidMount: function() {
-		const redirectURL = window.localStorage.getItem(RedirectLocation) || '/';
-		window.localStorage.removeItem(RedirectLocation);
+		const redirectURL = window.sessionStorage.getItem(RedirectLocation) || '/';
+		window.sessionStorage.removeItem(RedirectLocation);
 		setTimeout(function(){window.location=redirectURL;}, 1500);
  },
  render : function(){

--- a/client/naturalcrit/successPage/successPage.jsx
+++ b/client/naturalcrit/successPage/successPage.jsx
@@ -33,7 +33,7 @@ const SuccessPage = React.createClass({
 		};
 	},
 	componentDidMount: function() {
-		const redirectURL = window.localStorage.getItem(RedirectLocation) || '/login';
+		const redirectURL = window.localStorage.getItem(RedirectLocation) || '/';
 		window.localStorage.removeItem(RedirectLocation);
 		setTimeout(function(){window.location=redirectURL;}, 1500);
  },

--- a/client/naturalcrit/successPage/successPage.jsx
+++ b/client/naturalcrit/successPage/successPage.jsx
@@ -5,6 +5,8 @@ const cx    = require('classnames');
 const NaturalCritIcon = require('naturalcrit/svg/naturalcrit.svg.jsx');
 const AccountActions = require('../account.actions.js');
 
+const RedirectLocation = 'NC-REDIRECT-URL';
+
 const SuccessPage = React.createClass({
 	getDefaultProps: function() {
 		return {
@@ -31,7 +33,9 @@ const SuccessPage = React.createClass({
 		};
 	},
 	componentDidMount: function() {
-	  setTimeout(function(){window.location='/login';}, 1500);
+		const redirectURL = window.localStorage.getItem(RedirectLocation) || '/login';
+		window.localStorage.removeItem(RedirectLocation);
+		setTimeout(function(){window.location=redirectURL;}, 1500);
  },
  render : function(){
 	 return <div className='loginPage'>


### PR DESCRIPTION
This PR fixes redirection after logging in via Google.

In detail, on loading the Login page, the value of `redirect` from the URL parameter is stored in a local storage key. If there is no `redirect` value, the local storage key is cleared.
On successful completion of the Google authentication process, the Success page (which previously only redirected to `/login`) now checks the created local storage key, and redirects to the value stored there. If no value is found, it instead redirects to the `/login` page as normal.