### PR TITLE
Add forceSSL middleware (as used in HB)

### DIFF
--- a/server.js
+++ b/server.js
@@ -16,6 +16,7 @@ const app = express();
 app.use(express.static(__dirname + '/build'));
 app.use(bodyParser.json());
 app.use(cookieParser());
+app.use('/server/middleware/forcessl.mw.js');
 
 const config = require('nconf')
 	.argv()

--- a/server/middleware/forcessl.mw.js
+++ b/server/middleware/forcessl.mw.js
@@ -1,0 +1,7 @@
+module.exports = (req, res, next)=>{
+	if(process.env.NODE_ENV === 'local' || process.env.NODE_ENV === 'docker') return next();
+	if(req.header('x-forwarded-proto') !== 'https') {
+		return res.redirect(302, `https://${req.get('Host')}${req.url}`);
+	}
+	return next();
+};


### PR DESCRIPTION
This PR adds the `forceSSL.mw.js` middleware function, as used in Homebrewery, to automatically redirect any non-secure requests to secure endpoints.