### PR TITLE
Clean up `auth_routes.js`

### DIFF
--- a/server/auth_routes.js
+++ b/server/auth_routes.js
@@ -15,11 +15,11 @@ function generateUserToken(req, res) {
 
 // Login API
 router.post('/login', async (req, res) => {
-		const { user, pass } = req.body;
-		const jwt = await AccountModel.login(user, pass)
-			.catch(err => res.status(err.status || 500).json(err) );
-		if(jwt)
-			res.json(jwt);
+	const { user, pass } = req.body;
+	const jwt = await AccountModel.login(user, pass)
+		.catch(err => res.status(err.status || 500).json(err) );
+	if(jwt)
+		res.json(jwt);
 });
 
 // Render login page

--- a/server/auth_routes.js
+++ b/server/auth_routes.js
@@ -15,13 +15,11 @@ function generateUserToken(req, res) {
 
 // Login API
 router.post('/login', async (req, res) => {
-	try {
 		const { user, pass } = req.body;
-		const jwt = await AccountModel.login(user, pass);
-		res.json(jwt);
-	} catch (err) {
-		res.status(err.status || 500).json(err);
-	}
+		const jwt = await AccountModel.login(user, pass)
+			.catch(err => res.status(err.status || 500).json(err) );
+		if(jwt)
+			res.json(jwt);
 });
 
 // Render login page

--- a/server/auth_routes.js
+++ b/server/auth_routes.js
@@ -1,6 +1,6 @@
-const express = require('express');
-const passport = require('passport');
-const token = require('./token.js');
+const express      = require('express');
+const passport     = require('passport');
+const token        = require('./token.js');
 const AccountModel = require('./account.model.js').model; // Assuming this is needed for `login`.
 
 const router = express.Router();
@@ -50,10 +50,10 @@ router.get('/logout', (req, res) => {
 router.get(
 	'/google',
 	passport.authenticate('google', {
-		session: false, // No session should be maintained on the server.
-		scope: ['profile', 'https://www.googleapis.com/auth/drive.file'], // Request user profile and Google Drive file access.
-		accessType: 'offline', // Ensures refresh token is provided.
-		prompt: 'consent', // Forces user to select an account.
+		session    : false, // No session should be maintained on the server.
+		scope      : ['profile', 'https://www.googleapis.com/auth/drive.file'], // Request user profile and Google Drive file access.
+		accessType : 'offline', // Ensures refresh token is provided.
+		prompt     : 'consent', // Forces user to select an account.
 	})
 );
 
@@ -71,16 +71,16 @@ router.get(
 			const jwt = await generateUserToken(req, res);
 			console.log('About to redirect');
 			res.cookie('nc_session', jwt, {
-				maxAge: 1000 * 60 * 60 * 24 * 365, // 1 year
-				path: '/',
-				sameSite: 'lax',
-				domain: '.naturalcrit.com', // Set domain for the cookie.
 			});
 			res.redirect('/success');
 		} catch (err) {
 			console.error('Error during Google redirect:', err);
 			res.status(500).send('Internal Server Error');
 		}
+			maxAge   : 1000 * 60 * 60 * 24 * 365, // 1 year
+			path     : '/',
+			sameSite : 'lax',
+			domain   : '.naturalcrit.com', // Set domain for the cookie.
 	}
 );
 

--- a/server/auth_routes.js
+++ b/server/auth_routes.js
@@ -46,23 +46,18 @@ router.get('/google',
 // Google authentication redirect route
 router.get('/google/redirect',
 	passport.authenticate('google', { session: false }),
-	async (req, res, next) => {
-		try {
-			if (!req.user.username) {
-			}
-			res.cookie('nc_session', jwt, {
-			});
-			res.redirect('/success');
-		} catch (err) {
-			console.error('Error during Google redirect:', err);
-			res.status(500).send('Internal Server Error');
-		}
+	(req, res, next) => {
+		if (!req.user.username)
 			return next();	// Stay on the page if we still need local sign-in
+
 		const jwt = generateUserToken(req, res);
+		res.cookie('nc_session', jwt, {
 			maxAge   : 1000 * 60 * 60 * 24 * 365, // 1 year
 			path     : '/',
 			sameSite : 'lax',
 			domain   : '.naturalcrit.com', // Set domain for the cookie.
+		});
+		res.redirect('/success');
 	}
 );
 

--- a/server/auth_routes.js
+++ b/server/auth_routes.js
@@ -8,14 +8,9 @@ const router = express.Router();
 // TODO: MERGE from ACCOUNT.API.JS then probably rename ACCOUNT.API.JS
 
 // Helper function to generate a user token
-async function generateUserToken(req, res) {
-	try {
-		const accessToken = await token.generateAccessToken(req, res);
-		return accessToken;
-	} catch (err) {
-		console.error('Error generating user token:', err);
-		throw err;
-	}
+function generateUserToken(req, res) {
+	const accessToken = token.generateAccessToken(req, res);
+	return accessToken;
 }
 
 // Login API
@@ -59,7 +54,6 @@ router.get(
 		try {
 			if (!req.user.username) {
 			}
-			const jwt = await generateUserToken(req, res);
 			res.cookie('nc_session', jwt, {
 			});
 			res.redirect('/success');
@@ -68,6 +62,7 @@ router.get(
 			res.status(500).send('Internal Server Error');
 		}
 			return next();	// Stay on the page if we still need local sign-in
+		const jwt = generateUserToken(req, res);
 			maxAge   : 1000 * 60 * 60 * 24 * 365, // 1 year
 			path     : '/',
 			sameSite : 'lax',

--- a/server/auth_routes.js
+++ b/server/auth_routes.js
@@ -11,13 +11,7 @@ const router = express.Router();
 async function generateUserToken(req, res) {
 	try {
 		const accessToken = await token.generateAccessToken(req, res);
-		console.log('Successfully Generated JWT after Google Login');
-		console.log(accessToken);
 		return accessToken;
-		// Uncomment below if rendering an authenticated page instead of just returning the token.
-		// res.render('authenticated.html', {
-		//   token: accessToken
-		// });
 	} catch (err) {
 		console.error('Error generating user token:', err);
 		throw err;
@@ -63,13 +57,9 @@ router.get(
 	passport.authenticate('google', { session: false }),
 	async (req, res, next) => {
 		try {
-			// Check if there is an existing local user
 			if (!req.user.username) {
-				// Stay on the page if we still need local sign-in
-				return next();
 			}
 			const jwt = await generateUserToken(req, res);
-			console.log('About to redirect');
 			res.cookie('nc_session', jwt, {
 			});
 			res.redirect('/success');
@@ -77,6 +67,7 @@ router.get(
 			console.error('Error during Google redirect:', err);
 			res.status(500).send('Internal Server Error');
 		}
+			return next();	// Stay on the page if we still need local sign-in
 			maxAge   : 1000 * 60 * 60 * 24 * 365, // 1 year
 			path     : '/',
 			sameSite : 'lax',

--- a/server/auth_routes.js
+++ b/server/auth_routes.js
@@ -36,8 +36,7 @@ router.get('/logout', (req, res) => {
 });
 
 // Google authentication route
-router.get(
-	'/google',
+router.get('/google',
 	passport.authenticate('google', {
 		session    : false, // No session should be maintained on the server.
 		scope      : ['profile', 'https://www.googleapis.com/auth/drive.file'], // Request user profile and Google Drive file access.
@@ -47,8 +46,7 @@ router.get(
 );
 
 // Google authentication redirect route
-router.get(
-	'/google/redirect',
+router.get('/google/redirect',
 	passport.authenticate('google', { session: false }),
 	async (req, res, next) => {
 		try {


### PR DESCRIPTION
While troubleshooting the account renaming feature I made a note that this file has some easy opportunities for cleanup. Just applying those now before since I just saw my old note before I forget:

- Can remove async/await since the calls they are attached to are fully synchronous and involve no network calls
- Removing async/await reveals we can remove error handling for those paths since the areas in the `try {}` blocks cannot fail.
- Full removal of all try/catch blocks. Use `.catch()` instead in the one remaining async call.
- Removal / rearranging of comments/logs
- Aligning tabs/indents