### PR TITLE
Update AccountSchema.pre to not use `next()`

### DIFF
--- a/server/account.model.js
+++ b/server/account.model.js
@@ -14,7 +14,7 @@ const AccountSchema = mongoose.Schema({
 	googleRefreshToken : String,
 }, { versionKey: false });
 
-AccountSchema.pre('save', async function (next) {
+AccountSchema.pre('save', async function () {
 	try {
 		const account = this;
 		console.log(account);
@@ -22,9 +22,8 @@ AccountSchema.pre('save', async function (next) {
 			const salt = await bcrypt.genSalt(SALT_WORK_FACTOR);
 			account.password = await bcrypt.hash(account.password, salt);
 		}
-		next();
 	} catch (err) {
-		next({ ok: false, msg: 'Error generating password hash' });
+		throw({ ok: false, msg: 'Error generating password hash' });
 	}
 });
 


### PR DESCRIPTION
@5e-Cleric  This gets me past this error I was seeing at the google login redirect page:

```
TypeError: next is not a function at model.<anonymous> (file:///C:/Users/Trevor/Documents/GitHub/naturalcrit/server/account.model.js:27:3)
at Kareem.execPre (C:\Users\Trevor\Documents\GitHub\naturalcrit\node_modules\kareem\index.js:63:39)
at process.processTicksAndRejections (node:internal/process/task_queues:105:5) at async model.$__save (C:\Users\Trevor\Documents\GitHub\naturalcrit\node_modules\mongoose\lib\model.js:369:5)
at async model.save (C:\Users\Trevor\Documents\GitHub\naturalcrit\node_modules\mongoose\lib\model.js:609:5)
at async Strategy._verify (file:///C:/Users/Trevor/Documents/GitH
```

Maybe this is what you were running into?